### PR TITLE
Add categories and tags to non-collected Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,3 +42,4 @@ defaults:
       path: "writing"
     values:
       yahLit: true
+      category: default

--- a/_data/categories.yml
+++ b/_data/categories.yml
@@ -1,0 +1,8 @@
+# This Vortal Cord - Categories
+# Shizuka Kamishima - 2015-05-12
+#
+# - slug: cat-a                     (id to use in category frontmatter)
+#   name: Category A                (friendly name for category)
+#
+- slug: default
+  name: General

--- a/_data/categories.yml
+++ b/_data/categories.yml
@@ -6,3 +6,6 @@
 #
 - slug: default
   name: General
+
+- slug: catfoo
+  name: Cat Foo

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,0 +1,6 @@
+# This Vortal Cord - Tags
+# Shizuka Kamishima - 2015-05-12
+#
+# - slug: tag-a                     (id to use in tags frontmatter)
+#   name: Tag A                     (friendly name for tag)
+#

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -4,3 +4,5 @@
 # - slug: tag-a                     (id to use in tags frontmatter)
 #   name: Tag A                     (friendly name for tag)
 #
+- slug: tagbar
+  name: Tag Bar

--- a/writing/catdef-tagbar.md
+++ b/writing/catdef-tagbar.md
@@ -1,0 +1,8 @@
+---
+title: CatDef TagBar
+tags: [tagbar]
+---
+
+category default
+
+tags [tagbar]

--- a/writing/catdef-tagno.md
+++ b/writing/catdef-tagno.md
@@ -1,0 +1,7 @@
+---
+title: CatDef TagNone
+---
+
+category: default
+
+tags: none

--- a/writing/catfoo-tagbar.md
+++ b/writing/catfoo-tagbar.md
@@ -1,0 +1,9 @@
+---
+title: CatFoo TagBar
+category: catfoo
+tags: [tagbar]
+---
+
+category foo
+
+tags [tagbar]

--- a/writing/catfoo-tagno.md
+++ b/writing/catfoo-tagno.md
@@ -1,0 +1,8 @@
+---
+title: CatFoo TagNone
+category: catfoo
+---
+
+category foo
+
+tag none

--- a/writing/index.md
+++ b/writing/index.md
@@ -1,8 +1,16 @@
 ---
 title: writing
 layout: index
+notapost: true
 ---
 
 # writings
 
-foo bar baz quux
+
+{% for cat in site.data.categories %}
+<pre><code>
+CAT {{cat.slug}} - {{cat.name}}
+{% for page in (site.pages | where: "yahLit", true) %}{% if page.category == cat.slug %}
+  PAGE {{page.path}} - {{page.title}}
+{% endif %}{% endfor %}
+</code></pre>


### PR DESCRIPTION
Intended for use with Writing section, with pages grouped into categories and further grouped by tags in that category. A page could belong to one category, but multiple tags. A tag referenced by pages in multiple categories would just get duplicated, and not show pages outside their own category.

Requires horrible abuse of templating. May abandon this in favor of Collections `_writing` or straight up Posts.
